### PR TITLE
Haxe 4 sys threads for cs and eval thread fix

### DIFF
--- a/src/hx/concurrent/collection/Queue.hx
+++ b/src/hx/concurrent/collection/Queue.hx
@@ -15,7 +15,7 @@ import hx.concurrent.thread.Threads;
  */
 class Queue<T> {
 
-    #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+    #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
         var _queue = new sys.thread.Deque<T>();
     #elseif cpp
         var _queue = new cpp.vm.Deque<T>();
@@ -66,7 +66,7 @@ class Queue<T> {
             throw "[timeoutMS] must be >= -1";
 
         if (timeoutMS == 0) {
-            #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+            #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
                 msg = _queue.pop(false);
             #elseif (cpp||neko)
                 msg = _queue.pop(false);
@@ -81,7 +81,7 @@ class Queue<T> {
             #end
         } else {
             Threads.await(function() {
-                #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+                #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
                     msg = _queue.pop(false);
                 #elseif (cpp||neko)
                     msg = _queue.pop(false);
@@ -120,7 +120,7 @@ class Queue<T> {
         if (msg == null)
             throw "[msg] must not be null";
 
-        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
             _queue.push(msg);
         #elseif (cpp||neko)
             _queue.push(msg);
@@ -146,7 +146,7 @@ class Queue<T> {
         if (msg == null)
             throw "[msg] must not be null";
 
-        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
             _queue.add(msg);
         #elseif (cpp||neko)
             _queue.add(msg);

--- a/src/hx/concurrent/lock/RLock.hx
+++ b/src/hx/concurrent/lock/RLock.hx
@@ -23,7 +23,7 @@ class RLock implements Acquirable {
      */
     public static inline var isSupported = #if (eval||cpp||cs||flash||hl||java||neko||python) true #else false #end;
 
-    #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+    #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
         var _rlock = new sys.thread.Mutex();
     #elseif cpp
         var _rlock = new cpp.vm.Mutex();
@@ -111,7 +111,7 @@ class RLock implements Acquirable {
      * Blocks until lock can be acquired.
      */
     public function acquire():Void {
-        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
             _rlock.acquire();
         #elseif cs
             cs.system.threading.Monitor.Enter(this);
@@ -155,7 +155,7 @@ class RLock implements Acquirable {
 
     #if !flash inline #end
     private function tryAcquireInternal(timeoutMS = 0):Bool {
-        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
             return Threads.await(function() return _rlock.tryAcquire(), timeoutMS);
         #elseif cs
             return cs.system.threading.Monitor.TryEnter(this, timeoutMS);
@@ -203,7 +203,7 @@ class RLock implements Acquirable {
         else
             throw "Lock was not aquired by any thread!";
 
-        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
             _rlock.release();
         #elseif cs
             cs.system.threading.Monitor.Exit(this);

--- a/src/hx/concurrent/thread/Threads.hx
+++ b/src/hx/concurrent/thread/Threads.hx
@@ -21,11 +21,9 @@ class Threads {
      */
     public static var current(get, never):Dynamic;
     static function get_current():Dynamic {
-        #if ((haxe_ver >= 4) && eval)
-            return sys.thread.Thread.current().id();
-        #elseif ((haxe_ver >= 4) && hl)
+        #if ((haxe_ver >= 4) && hl)
             return Std.string(sys.thread.Thread.current());
-        #elseif ((haxe_ver >= 4) && (neko || cpp || java))
+        #elseif ((haxe_ver >= 4) && (neko || cpp || java || eval || cs))
             return sys.thread.Thread.current();
         #elseif cpp
             return cpp.vm.Thread.current().handle;
@@ -141,7 +139,7 @@ class Threads {
      */
     inline
     public static function spawn(func:Void->Void):Void {
-        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java))
+        #if ((haxe_ver >= 4) && (eval || neko || cpp || hl || java || cs))
             sys.thread.Thread.create(func);
         #elseif cpp
             cpp.vm.Thread.create(func);


### PR DESCRIPTION
Hello,
Some more haxe 4 changes. Fixes getting the current thread for eval as `sys.thread.Thread` doesn't have an id function and sets C# to use the new sys threads when targeting haxe 4.

Cheers